### PR TITLE
Reduces risk of concurrency issues on writing and reading the file backend cache

### DIFF
--- a/Classes/Hooks/RenderPreProcessorHook.php
+++ b/Classes/Hooks/RenderPreProcessorHook.php
@@ -141,6 +141,8 @@ class RenderPreProcessorHook
             try {
                 if ($contentHashCache == '' || $contentHashCache != $contentHash) {
                     $css = $this->compileScss($scssFilename, $cssFilename, $this->variables, $showLineNumber, $formatter);
+
+                    $cache->set($cacheKey, $contentHash, array());
                 }
             } catch (\Exception $ex) {
                 // log the exception to the TYPO3 log as error
@@ -149,8 +151,6 @@ class RenderPreProcessorHook
                 GeneralUtility::sysLog($ex->getMessage(), GeneralUtility::SYSLOG_SEVERITY_ERROR);
 
             }
-
-            $cache->set($cacheKey, $contentHash, array());
 
             if ($inlineOutput) {
                 unset($cssFiles[$cssRelativeFilename]);


### PR DESCRIPTION
Hi Sven

We have discovered that the following error keeps filling our production error logs:

```
file_get_contents(/var/www/example.ch/typo3temp/Cache/Data/ws_scss/57e88152234494f0a52e0e7893d30440eb8d9cef): 
failed to open stream: No such file or directory in /var/www/example.ch/typo3_src-7.6.16/typo3/sysext/core/Classes/Cache/Backend/FileBackend.php line 198
```

The error occurs seemingly at random time intervals several times in an hour. The error does not occur on our test environment nor on our local development environment.
After some analysis I figured out that this happens most likely due to a concurrency issue using the TYPO3 FileBackend cache. 

When using the method `$cache->set(...)` the FileBackend cache always deletes the cache file before it creates a new one. The following example shows how two interleaving requests could lead to the error above:

```
Request 1: $cache->has('a') --> true
Request 2: $cache->has('a') --> true
Request 1: $cache->get('a')
Request 1: $cache-set('a')
Request 1: --> FileBackend->remove(), TYPO3 removes the file and creates a new one later
Request 2: $cache->get('a') --> BOOM! file does not exist error
Request 1: --> FileBackend->create(), TYPO3 creates a new cache file
```

My proposal to reduce the risk of that occurring is to move the `$cache->set()` call to the location where the Sass files are actually compiled. Like this we only set the cache hash when it did not exist before or when it changed (which should be enough). That also reduces the delete and write operations on every request.
I have tested it locally on my machine and it seems to work perfectly fine.

That fix still leaves the possibility for concurrency issues to occur, but they should become very very seldom. Any further improvement would most likely be overkill.