### PR TITLE
Updated class name in localconf

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -3,7 +3,7 @@ if (!defined('TYPO3_MODE')) {
 	die('Access denied.');
 }
 
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_pagerenderer.php']['render-preProcess']['wsscss'] = 'EXT:ws_scss/Classes/Hooks/RenderPreProcessorHook.php:&WapplerSystems\WsScss\Hooks\RenderPreProcessorHook->renderPreProcessorProc';
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_pagerenderer.php']['render-preProcess']['wsscss'] = 'WapplerSystems\\WsScss\\Hooks\\RenderPreProcessorHook->renderPreProcessorProc';
 
 // Caching the pages - default expire 3600 seconds
 if (!is_array($TYPO3_CONF_VARS['SYS']['caching']['cacheConfigurations']['ws_scss'])) {


### PR DESCRIPTION
Use new naming scheme. Support for the old EXT:... was removed in Typo3 9.0.