### PR TITLE
Add HTTP_HOST to $defaultOutputDir

### DIFF
--- a/Classes/Hooks/RenderPreProcessorHook.php
+++ b/Classes/Hooks/RenderPreProcessorHook.php
@@ -66,7 +66,7 @@ class RenderPreProcessorHook
             return;
         }
 
-        $defaultOutputDir = 'typo3temp/assets/css/';
+        $defaultOutputDir = 'typo3temp/assets/css/' . GeneralUtility::getIndpEnv('HTTP_HOST') . '/';
         if (VersionNumberUtility::convertVersionNumberToInteger(VersionNumberUtility::getCurrentTypo3Version()) < VersionNumberUtility::convertVersionNumberToInteger('8.0.0')) {
             $defaultOutputDir = 'typo3temp/';
         }


### PR DESCRIPTION
Add HTTP_HOST to $defaultOutputDir to prevent problem when cache was cleared and all hosts are loaded at the same time on a multi domain website.