### PR TITLE
[TASK] Set mkdir recursive mode for creating subfolders in cache path

### DIFF
--- a/Resources/Private/scssphp/src/Cache.php
+++ b/Resources/Private/scssphp/src/Cache.php
@@ -177,7 +177,7 @@ class Cache
         self::$cacheDir = rtrim(self::$cacheDir, '/') . '/';
 
         if (! is_dir(self::$cacheDir)) {
-            if (! mkdir(self::$cacheDir)) {
+            if (! mkdir(self::$cacheDir, 0777, 1)) {
                 throw new Exception('Cache directory couldn\'t be created: ' . self::$cacheDir);
             }
         }


### PR DESCRIPTION
I had to set the recursive flag for mkdir because my cache folder /typo3temp/assets/css/cache could not be created