### PR TITLE
Add the extension key to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,10 @@
         "psr-4": {
             "WapplerSystems\\WsScss\\": "Classes/"
         }
+    },
+    "extra": {
+        "typo3-cms": {
+            "extension-key": "ws_scss"
+        }
     }
 }


### PR DESCRIPTION
Not defining the extension key now triggers a warning and will be a hard
error in future TYPO3 versions.