### PR TITLE
prevent console error

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -8,7 +8,8 @@ if (TYPO3_MODE === 'FE') {
 }
 
 // Caching the pages - default expire 3600 seconds
-if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['ws_scss'])) {
+if (isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['ws_scss'])
+&& !is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['ws_scss'])) {
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['ws_scss'] = [
 		'frontend' => \TYPO3\CMS\Core\Cache\Frontend\VariableFrontend::class,
 		'backend' => \TYPO3\CMS\Core\Cache\Backend\FileBackend::class,


### PR DESCRIPTION
`$ php vendor/bin/typo3cms --verbose`

  [ TYPO3\CMS\Core\Error\Exception ]
  Warning: Undefined array key "ws_scss" in source/typo3conf/ext/ws_scss/ext_localconf.php line 11