### PR TITLE
Update RenderPreProcessorHook.php

### DIFF
--- a/Classes/Hooks/RenderPreProcessorHook.php
+++ b/Classes/Hooks/RenderPreProcessorHook.php
@@ -191,7 +191,8 @@ class RenderPreProcessorHook
                     $cache->set($cacheKey, $contentHash, ['scss'], 0);
                 }
             } catch (\Exception $ex) {
-                if(!GeneralUtility::getApplicationContext()->isProduction()) {
+                $applicationContext = \TYPO3\CMS\Core\Core\Environment::getContext();
+                if(!$applicationContext->isProduction()) {
                     DebugUtility::debug($ex->getMessage());
                 }
 


### PR DESCRIPTION
Change how to get ApplicationContext. It is not supported by GeneralUtility anymore. see https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/10.2/Deprecation-89631-UseEnvironmentAPIToFetchApplicationContext.html