### PR TITLE
cleanup indentation @ `Compiler.php`

### DIFF
--- a/Classes/Compiler.php
+++ b/Classes/Compiler.php
@@ -138,15 +138,15 @@ class Compiler
 
         try {
             $result = $parser->compileString('@import "' . $scssFilePath . '";');
-	        $cssCode = $result->getCss();
+            $cssCode = $result->getCss();
 
-	        $eventDispatcher = GeneralUtility::makeInstance(\Psr\EventDispatcher\EventDispatcherInterface::class);
-	        $event = $eventDispatcher->dispatch(
-		        new AfterScssCompilationEvent($cssCode)
-	        );
-	        $cssCode = $event->getCssCode();
+            $eventDispatcher = GeneralUtility::makeInstance(\Psr\EventDispatcher\EventDispatcherInterface::class);
+            $event = $eventDispatcher->dispatch(
+                new AfterScssCompilationEvent($cssCode)
+            );
+            $cssCode = $event->getCssCode();
 
-	        $cache->set($cacheKey, $calculatedContentHash, ['scss'], 0);
+            $cache->set($cacheKey, $calculatedContentHash, ['scss'], 0);
             GeneralUtility::mkdir_deep(dirname(GeneralUtility::getFileAbsFileName($cssFilePath)));
             GeneralUtility::writeFile(GeneralUtility::getFileAbsFileName($cssFilePath), $cssCode);
         } catch (\Exception $ex) {


### PR DESCRIPTION
`\t` => `\s{4}`

fyi/ ignored `\t` @ https://github.com/WapplerSystems/ws_scss/pull/76/files#diff-b62d734abfecb0f85c66299824783a8e9f113434d13a4cf02ce9ac634b76f756