### PR TITLE
Fix caching bug in multi-site/multi-variable environments

### DIFF
--- a/Classes/Compiler.php
+++ b/Classes/Compiler.php
@@ -102,7 +102,7 @@ class Compiler
         /** @var FileBackend $cache */
         $cache = GeneralUtility::makeInstance(CacheManager::class)->getCache('ws_scss');
 
-        $cacheKey = hash('sha1', $scssFilePath);
+        $cacheKey = hash('sha1', $scssFilePath . ($variablesHash ?? ''));
         $calculatedContentHash = self::calculateContentHash($scssFilePath, $variables);
         $calculatedContentHash .= md5($cssFilePath);
         if ($useSourceMap) {


### PR DESCRIPTION
In Compiler.php the cache key generation does not take different variables for different sites into account. Thus, CSS gets compiled over and over again when requests to one site overwrite the cache of another site (with different variables)

By the way: Great extension!

Thanks & cheers
Sven