### PR TITLE
Added variable conversion for "px" values

### DIFF
--- a/Classes/Compiler.php
+++ b/Classes/Compiler.php
@@ -133,6 +133,8 @@ class Compiler
         foreach ($variables as $varName => $varValue) {
             if (str_ends_with($varValue, 'rem')) {
                 $convertedVariables[$varName] = SassNumber::create((float)$varValue, 'rem');
+            } elseif (str_ends_with($varValue, 'px')) {
+                $convertedVariables[$varName] = SassNumber::create((int)$varValue, 'px');
             } elseif (str_starts_with($varValue, '#')) {
                 $rgb = self::hex2rgb($varValue);
                 $convertedVariables[$varName] = SassColor::rgb($rgb[0], $rgb[1], $rgb[2]);


### PR DESCRIPTION
When trying to use `px` as a unit in the TypoScript variables, the following error occurs:

`$number: "576px" is not a number. , 11 | @if $prev-num == null or uni
 t($num) == "%" or unit($prev-num) == "%" { |
  ^^^^^^^^^^ ' /var/www/html/vendor...`

I've added another `elseif` to also convert variables with that unit.