### PR TITLE
[BUGFIX] Fix SCSS compilation hash and outputfile path handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /.project
 /.settings
 /.idea
+/.vscode
+/.classpath
+/.factorypath

--- a/Classes/Compiler.php
+++ b/Classes/Compiler.php
@@ -152,7 +152,7 @@ class Compiler
         } catch (\Exception $ex) {
             DebugUtility::debug($ex->getMessage());
 
-            /** @var $logger Logger */
+            /** @var Logger $logger */
             $logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(__CLASS__);
             $logger->error($ex->getMessage());
         }
@@ -180,7 +180,7 @@ class Compiler
         $pathInfo = pathinfo($scssFileName);
 
         $hash = hash('sha1', $content);
-        if ($vars !== '') {
+        if ($vars !== []) {
             $hash = hash('sha1', $hash . implode(',', $vars));
         } // hash variables too
 
@@ -189,14 +189,14 @@ class Compiler
             $hashImport = '';
 
             if (file_exists($pathInfo['dirname'] . '/' . $import . '.scss')) {
-                $hashImport = self::calculateContentHash($pathInfo['dirname'] . '/' . $import . '.scss', $visitedFiles);
+                $hashImport = self::calculateContentHash($pathInfo['dirname'] . '/' . $import . '.scss', $vars, $visitedFiles);
             } else {
                 $parts = explode('/', $import);
                 $filename = '_' . array_pop($parts);
                 $parts[] = $filename;
                 if (file_exists($pathInfo['dirname'] . '/' . implode('/', $parts) . '.scss')) {
                     $hashImport = self::calculateContentHash($pathInfo['dirname'] . '/' . implode('/',
-                            $parts) . '.scss', [], $visitedFiles);
+                            $parts) . '.scss', $vars, $visitedFiles);
                 }
             }
             if ($hashImport !== '') {

--- a/Classes/Compiler.php
+++ b/Classes/Compiler.php
@@ -90,7 +90,9 @@ class Compiler
         /** @var FileBackend $cache */
         $cache = GeneralUtility::makeInstance(CacheManager::class)->getCache('ws_scss');
 
-        $cacheKey = hash('sha1', $scssFilePath);
+        // Include cssFilePath in cache key so different outputfile targets
+        // (e.g. theme.css vs themeSkarupke.css) get separate cache entries
+        $cacheKey = hash('sha1', $scssFilePath . '|' . $cssFilePath);
         $calculatedContentHash = self::calculateContentHash($scssFilePath, $variables);
         $calculatedContentHash .= md5($cssFilePath);
         if ($useSourceMap) {
@@ -126,6 +128,12 @@ class Compiler
         $parser = new \ScssPhp\ScssPhp\Compiler($cacheOptions);
         $parser->addVariables($variables);
         $parser->setOutputStyle($outputStyle);
+
+        // Add vendor directory as import path so SCSS files can use
+        // @import "vendor-name/package-name/..." without fragile relative paths
+        foreach (self::getAdditionalImportPaths() as $importPath) {
+            $parser->addImportPath($importPath);
+        }
 
         if ($useSourceMap) {
             $parser->setSourceMap(\ScssPhp\ScssPhp\Compiler::SOURCE_MAP_INLINE);
@@ -199,12 +207,49 @@ class Compiler
                             $parts) . '.scss', $vars, $visitedFiles);
                 }
             }
+
+            // Fallback: resolve via additional import paths (e.g. vendor/)
+            if ($hashImport === '') {
+                foreach (self::getAdditionalImportPaths() as $importBasePath) {
+                    if (file_exists($importBasePath . '/' . $import . '.scss')) {
+                        $hashImport = self::calculateContentHash($importBasePath . '/' . $import . '.scss', $vars, $visitedFiles);
+                        break;
+                    }
+                    $parts = explode('/', $import);
+                    $filename = '_' . array_pop($parts);
+                    $parts[] = $filename;
+                    if (file_exists($importBasePath . '/' . implode('/', $parts) . '.scss')) {
+                        $hashImport = self::calculateContentHash($importBasePath . '/' . implode('/', $parts) . '.scss', $vars, $visitedFiles);
+                        break;
+                    }
+                }
+            }
+
             if ($hashImport !== '') {
                 $hash = hash('sha1', $hash . $hashImport);
             }
         }
 
         return $hash;
+    }
+
+
+    /**
+     * Get additional import paths for the SCSS compiler.
+     * Adds the Composer vendor directory so SCSS files can import
+     * packages using vendor-relative paths (e.g. "vendor-name/package-name/...").
+     *
+     * @return array<string>
+     */
+    private static function getAdditionalImportPaths(): array
+    {
+        $paths = [];
+        $vendorPath = Environment::getProjectPath() . '/vendor';
+        if (is_dir($vendorPath)) {
+            $paths[] = $vendorPath;
+        }
+
+        return $paths;
     }
 
 

--- a/Classes/Hooks/RenderPreProcessorHook.php
+++ b/Classes/Hooks/RenderPreProcessorHook.php
@@ -127,13 +127,13 @@ class RenderPreProcessorHook
                         $subConf = $GLOBALS['TSFE']->pSetup['includeCSS.'][$key . '.'] ?? [];
 
                         $outputFilePath = $subConf['outputfile'] ?? null;
-                        $useSourceMap = $this->parseBooleanSetting($subConf['sourceMap'] ?? false, false);
-                        $unlink = $this->parseBooleanSetting($subConf['unlink'] ?? false, false);
+                        $useSourceMap = $this->parseBooleanSetting($subConf['sourceMap'] ?? '', false);
+                        $unlink = $this->parseBooleanSetting($subConf['unlink'] ?? '', false);
                         if (isset($subConf['outputStyle']) && ($subConf['outputStyle'] === 'expanded' || $subConf['outputStyle'] === 'compressed')) {
                             $outputStyle = $subConf['outputStyle'];
                         }
                         $variables = array_filter($subConf['variables.'] ?? []);
-                        $inlineOutput = $this->parseBooleanSetting($GLOBALS['TSFE']->pSetup['includeCSS.'][$key . '.']['inlineOutput'] ?? false, false);
+                        $inlineOutput = $this->parseBooleanSetting($GLOBALS['TSFE']->pSetup['includeCSS.'][$key . '.']['inlineOutput'] ?? '', false);
                     }
                 }
             }
@@ -163,6 +163,13 @@ class RenderPreProcessorHook
                 unset($conf['tagAttributes']['sourceMap']);
                 unset($conf['tagAttributes']['variables.']);
                 unset($conf['tagAttributes']['outputfile']);
+                unset($conf['tagAttributes']['outputStyle']);
+                unset($conf['tagAttributes']['unlink']);
+
+                if ($outputFilePath !== null) {
+                    $conf['compress'] = false;
+                    $cssFilePath = '/' . ltrim($cssFilePath, '/');
+                }
 
                 $cssFiles[$cssFilePath] = $conf;
                 $cssFiles[$cssFilePath]['file'] = $cssFilePath;

--- a/Classes/Hooks/RenderPreProcessorHook.php
+++ b/Classes/Hooks/RenderPreProcessorHook.php
@@ -92,6 +92,18 @@ class RenderPreProcessorHook
                     $parsedTypoScriptVariables[$variable] = $key;
                 }
             }
+
+            // Resolve EXT: prefixes in variable values to web-accessible paths
+            // e.g. "EXT:fontawesome/Resources/Public/..." → "/_assets/{hash}/..."
+            foreach ($parsedTypoScriptVariables as $variable => $value) {
+                if (is_string($value) && str_starts_with($value, 'EXT:')) {
+                    $absolutePath = GeneralUtility::getFileAbsFileName($value);
+                    if ($absolutePath !== '' && (file_exists($absolutePath) || is_dir($absolutePath))) {
+                        $parsedTypoScriptVariables[$variable] = PathUtility::getAbsoluteWebPath($absolutePath);
+                    }
+                }
+            }
+
             $this->variables = $parsedTypoScriptVariables;
         }
 


### PR DESCRIPTION
- Fix calculateContentHash:  was compared to string instead of array
- Fix calculateContentHash: recursive calls had wrong parameter order ( passed as ,  lost on partial imports)
- Fix outputfile path: ensure absolute web path with leading /
- Disable compress for custom outputfile to prevent duplicate files
- Fix type safety: parseBooleanSetting received bool instead of string
- Clean up unused tagAttributes (outputStyle, unlink)

Resolves: #1